### PR TITLE
Remove --reload from production api-server CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ CMD ["$@"]
 
 FROM base AS api-server
 # Start the application
-CMD ["uvicorn", "main:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000", "--workers", "4", "--reload"] 
+CMD ["uvicorn", "main:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]


### PR DESCRIPTION
- Removes `--reload` from the `api-server` stage `CMD` in the Dockerfile. `--reload` enables filesystem watching + auto-restarts (a dev-only feature) and conflicts with `--workers 4` — uvicorn ignores the worker count when reload is enabled, so the production image was effectively running a single dev-mode worker.
- The local-dev `--reload` usage documented in the README (`uvicorn main:create_app --factory ... --reload`) is intentionally left untouched.
- Verified: `ruff check .` passes (all checks passed), pytest passes (18 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)